### PR TITLE
Scripts now accept any dataloader version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The open source version of dataloader is available from: https://github.com/forc
 1. Java 1.6+, available in the PATH
 
 2. DataLoader JAR file from Windows or built from the open source project. 
-(The current name/version of the jar file is: dataloader-30.0.0-uber.jar)
+(The current name/version of the jar file is: dataloader-30.0.0-uber.jar, tested with 40.0.0 as well.)
 
 ##Steps: 
 

--- a/bin/encrypt.sh
+++ b/bin/encrypt.sh
@@ -6,5 +6,5 @@ if [ "$JAVA" == "" ]; then
         echo "Unable to find Java Runtime in PATH";
         exit -1;
 else
-	$JAVA -cp dataloader-30.0.0-uber.jar com.salesforce.dataloader.security.EncryptionUtil "$@" | sed 's/^.*) \- //g'
+	$JAVA -cp dataloader-*-uber.jar com.salesforce.dataloader.security.EncryptionUtil "$@" | sed 's/^.*) \- //g'
 fi

--- a/bin/process.sh
+++ b/bin/process.sh
@@ -26,6 +26,6 @@ if [ "$JAVA" == "" ]; then
   echo "Unable to find Java Runtime in PATH"
   exit -1
 else
-  $JAVA -cp dataloader-30.0.0-uber.jar -Dsalesforce.config.dir=$CONF_DIR com.salesforce.dataloader.process.ProcessRunner process.name=$PROCESS
+  $JAVA -cp dataloader-*-uber.jar -Dsalesforce.config.dir=$CONF_DIR com.salesforce.dataloader.process.ProcessRunner process.name=$PROCESS
 fi
 


### PR DESCRIPTION
Cool repo and I could run it just fine with dataloader v40 :+1:. Only issue I had during the setup was that the scripts excpected hardcoded v30 filenames. So I've modified the scripts to accept wildcard version and I also mentioned v40 running fine.